### PR TITLE
Split scenario name and run date when query is retrieved from model interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgcam
 Title: Tools for importing and working with GCAM results
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: person("Robert", "Link", email = "robert.link@pnnl.gov", role = c("aut", "cre"))
 Description: This package provides tools for extracting data from GCAM
     output databases and importing that data into R for analysis.  The

--- a/R/importgcam.R
+++ b/R/importgcam.R
@@ -448,7 +448,10 @@ table.cleanup <- function(tbl)
 ## just the name of the scenario, without the date information that is typically
 ## packed into that column.
 table.scen.trim <- function(tbl) {
-    dplyr::mutate(tbl, scenario=sep.date(scenario)[['scenario']])
+    scendate <- sep.date(tbl[['scenario']])
+    dplyr::mutate(tbl,
+                  scenario=scendate[['scenario']],
+                  rundate=scendate[['date']])
 }
 
 #' Standardize the case of a table's columns.

--- a/R/importmisc.R
+++ b/R/importmisc.R
@@ -67,19 +67,16 @@ addQueryTable <- function(project, qdata, queryname, clobber=FALSE,
 
     project <- loadProject(project)
 
-    ## standardize the case of column names.
-    qdata <- stdcase(qdata)
-
-    ## Check to see if the scenario name includes a date marker.  If so, split
-    ## the date into its own column.
-    if(all(grepl('date=', qdata$scenario))) {
-        sd <- sep.date(qdata$scenario)
-        qdata <- dplyr::mutate(qdata, scenario=sd[['scenario']],
-                               rundate=sd[['date']])
+    ## check to see if we have a rundate column.  It should be produced
+    ## automatically when the query is run, but some legacy data might not have
+    ## it.  This will also standardize the case of the column names.
+    if(!('rundate' %in% names(qdata))) {
+        qdata <- table.cleanup(qdata)
     }
     else {
-        ## don't have dates, so put in an NA placeholder for now
-        qdata <- dplyr::mutate(qdata, rundate=NA)
+        ## standardize the case of column names.  Again, this should have
+        ## already been done, but this covers us in case of legacy data.
+        qdata <- stdcase(qdata)
     }
 
     if(!is.null(transformation)) {

--- a/R/querymi.R
+++ b/R/querymi.R
@@ -187,5 +187,5 @@ miquery_post <- function(results, query, scenarios, regions, warn.empty) {
           group_by_(.dots=paste0('`',names(results)[names(results) != "value"],'`')) %>%
           summarize(value=sum(value)) %>% ungroup()
     }
-    results
+    table.cleanup(results)
 }

--- a/tests/testthat/test_data_wrangle.R
+++ b/tests/testthat/test_data_wrangle.R
@@ -1,5 +1,4 @@
-library('rgcam')
-library('dplyr')
+library('dplyr', warn.conflicts = FALSE, quietly = TRUE)
 
 context('GCAM data wrangling')
 

--- a/tests/testthat/test_data_wrangle.R
+++ b/tests/testthat/test_data_wrangle.R
@@ -63,3 +63,17 @@ test_that('scenarioDiff: throws errors for bad arguments.', {
               expect_error(diffScenarios(scenboth, data2=sceny),
                            'each must contain exactly one')
           })
+
+test_that('separating scenarion name from date works.', {
+    scenario <- rep("Reference-filtered,date=2016-13-12T05:31:05-08:00", 4)
+    scendate <- sep.date(scenario)
+    expect_true(all(scendate$scenario == 'Reference-filtered'))
+    refdate <- lubridate::ymd_hms('2016-12-13 13:31:05')
+    expect_true(all(scendate$date == refdate))
+    if(any(scendate$date != refdate)) {
+        baddate <- (scenario[scendate$date != refdate])[1]
+        splt <- stringr::str_split_fixed(baddate,',date=',2)
+        expect_true(FALSE, info=paste('scenario string: ', baddate, ' split[1]= ',
+                                      splt[1], ' split[2]= ', splt[2]))
+    }
+})

--- a/tests/testthat/test_querymi.R
+++ b/tests/testthat/test_querymi.R
@@ -4,6 +4,9 @@ SAMPLE.GCAMDBLOC <- system.file("extdata",
                                 package="rgcam")
 SAMPLE.QUERIES <- system.file("ModelInterface", "sample-queries.xml",
                               package="rgcam")
+refscen <- 'Reference-filtered'
+refdate <- lubridate::ymd_hms('2016-12-13 13:31:05')
+
 conn <- localDBConn(SAMPLE.GCAMDBLOC, "sample_basexdb")
 queries <- parse_batch_query(SAMPLE.QUERIES)
 
@@ -31,15 +34,17 @@ test_that('runQuery works with default arguments and local db', {
                                           "value", "rundate"))
               expect_equal(min(rslt$year), 1975)
               expect_equal(max(rslt$year), 2100)
-              expect_true(all(rslt$scenario == 'Reference-filtered'))
+              expect_true(all(rslt$scenario == refscen))
               expect_true(all(rslt$region == 'USA'))
-              expect_true(all(rslt$rundate == '2016-12-13 08:31:05'))
+              crd <- class(rslt$rundate)
+              lrd <- rslt$rundate == refdate
+              expect_true(all(lrd), info=paste('rundate class= ', crd, ' failval= ', (rslt$rundate[lrd])[1]))
           })
 
 test_that('runQuery works with explicit arguments and local db', {
               queries <- parse_batch_query(SAMPLE.QUERIES)
               expect_silent({rslt <- runQuery(conn, queries[[4]]$query,
-                                              scenarios='Reference-filtered',
+                                              scenarios=refscen,
                                               regions='USA')})
               expect_true(is.data.frame(rslt))
               expect_equal(nrow(rslt), 22)
@@ -47,9 +52,9 @@ test_that('runQuery works with explicit arguments and local db', {
                                           "value", "rundate"))
               expect_equal(min(rslt$year), 1975)
               expect_equal(max(rslt$year), 2100)
-              expect_true(all(rslt$scenario == 'Reference-filtered'))
+              expect_true(all(rslt$scenario == refscen))
               expect_true(all(rslt$region == 'USA'))
-              expect_true(all(rslt$rundate == '2016-12-13 08:31:05'))
+              expect_true(all(rslt$rundate == refdate))
 })
 
 test_that('warnings issued appropriately for empty tables', {
@@ -129,7 +134,7 @@ test_that('empty region queries all region for XQuery style queries', {
         </supplyDemandQuery>'
 
     expect_silent({bld_data <- runQuery(conn, bld_xquery_query,
-                                    scenarios='Reference-filtered',
+                                    scenarios=refscen,
                                     regions=c())})
     # Note the sample DB has been filtered to only include just the region "USA"
     # which is not ideal for the sake of this test since we would want to ensure

--- a/tests/testthat/test_querymi.R
+++ b/tests/testthat/test_querymi.R
@@ -27,8 +27,13 @@ test_that('runQuery works with default arguments and local db', {
               expect_silent({rslt <- runQuery(conn, queries[[4]]$query)})
               expect_true(is.data.frame(rslt))
               expect_equal(nrow(rslt), 22)
-              expect_equal(names(rslt), c("Units", "scenario", "region", "Year",
-                                          "value"))
+              expect_equal(names(rslt), c("Units", "scenario", "region", "year",
+                                          "value", "rundate"))
+              expect_equal(min(rslt$year), 1975)
+              expect_equal(max(rslt$year), 2100)
+              expect_true(all(rslt$scenario == 'Reference-filtered'))
+              expect_true(all(rslt$region == 'USA'))
+              expect_true(all(rslt$rundate == '2016-12-13 08:31:05'))
           })
 
 test_that('runQuery works with explicit arguments and local db', {
@@ -38,9 +43,14 @@ test_that('runQuery works with explicit arguments and local db', {
                                               regions='USA')})
               expect_true(is.data.frame(rslt))
               expect_equal(nrow(rslt), 22)
-              expect_equal(names(rslt), c("Units", "scenario", "region", "Year",
-                                          "value"))
-          })
+              expect_equal(names(rslt), c("Units", "scenario", "region", "year",
+                                          "value", "rundate"))
+              expect_equal(min(rslt$year), 1975)
+              expect_equal(max(rslt$year), 2100)
+              expect_true(all(rslt$scenario == 'Reference-filtered'))
+              expect_true(all(rslt$region == 'USA'))
+              expect_true(all(rslt$rundate == '2016-12-13 08:31:05'))
+})
 
 test_that('warnings issued appropriately for empty tables', {
               expect_warning({rslt <- runQuery(conn, queries[[4]]$query,


### PR DESCRIPTION
The "scenario" column now contains just the scenario name.  The date
portion is automatically put into a column called "rundate".  This
happens in the cleanup at the end of runQuery, so in theory no table
should make it into the system without having this transformation
applied.  In practice we do some checks in later stages to make sure
that we don't get burned by legacy data that doesn't conform to this
convention.