### PR TITLE
Fix bug where we were unable to run queries with CDATA sections on

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgcam
 Title: Tools for importing and working with GCAM results
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: person("Robert", "Link", email = "robert.link@pnnl.gov", role = c("aut", "cre"))
 Description: This package provides tools for extracting data from GCAM
     output databases and importing that data into R for analysis.  The

--- a/R/querymi.R
+++ b/R/querymi.R
@@ -174,6 +174,8 @@ runQuery.remoteDBConn <- function(dbConn, query, scenarios=NULL, regions=NULL,
                                   warn.empty=TRUE) {
     xqScenarios <- ifelse(length(scenarios) == 0, "()", paste0("('", paste(scenarios, collapse="','"), "')"))
     xqRegion <- ifelse(length(regions) == 0, "()", paste0("('", paste(regions, collapse="','"), "')"))
+    # handle nested CDATA tags
+    query <- gsub(']]>', ']]]]><![CDATA[>', query)
     restQuery <- paste(
         '<rest:query xmlns:rest="http://basex.org/rest">',
             '<rest:text><![CDATA[',


### PR DESCRIPTION
remoteDBConn.  We simply needed to escape the close to avoid nested
CDATA sections which is illegal. This closes #28.