### PR TITLE
Drop row.names argument from read.csv call in addQueryTable

### DIFF
--- a/R/importmisc.R
+++ b/R/importmisc.R
@@ -62,7 +62,7 @@ addQueryTable <- function(project, qdata, queryname, clobber=FALSE,
     ## Check to see if either of the inputs are file names and if so replace
     ## them with the actual data.
     if(is.character(qdata)) {
-        qdata <- read.csv(qdata, row.names=FALSE)
+        qdata <- read.csv(qdata)
     }
 
     project <- loadProject(project)

--- a/R/importmisc.R
+++ b/R/importmisc.R
@@ -54,15 +54,17 @@
 #' @param strict.rundate Flag: if \code{TRUE}, then require that the run dates
 #' match in order to add queries to a scenario, and fail the entire operation if
 #' they don't.  If \code{FALSE}, then ignore dates in the new data set.
+#' @param ... Additional parameters to be passed to \code{read.csv} if \code{qdata}
+#' is a file name and therefore will get read from csv.
 #' @export
 addQueryTable <- function(project, qdata, queryname, clobber=FALSE,
                           transformation=NULL, saveProj=TRUE,
-                          strict.rundate=FALSE)
+                          strict.rundate=FALSE, ...)
 {
     ## Check to see if either of the inputs are file names and if so replace
     ## them with the actual data.
     if(is.character(qdata)) {
-        qdata <- read.csv(qdata)
+        qdata <- read.csv(qdata, ...)
     }
 
     project <- loadProject(project)

--- a/man/addQueryTable.Rd
+++ b/man/addQueryTable.Rd
@@ -5,7 +5,7 @@
 \title{Import a table of data into a project data set as a new query.}
 \usage{
 addQueryTable(project, qdata, queryname, clobber = FALSE,
-  transformation = NULL, saveProj = TRUE, strict.rundate = FALSE)
+  transformation = NULL, saveProj = TRUE, strict.rundate = FALSE, ...)
 }
 \arguments{
 \item{project}{The project data set to add the query to.  This can be either
@@ -32,6 +32,9 @@ calling \code{saveProject}.}
 \item{strict.rundate}{Flag: if \code{TRUE}, then require that the run dates
 match in order to add queries to a scenario, and fail the entire operation if
 they don't.  If \code{FALSE}, then ignore dates in the new data set.}
+
+\item{...}{Additional parameters to be passed to \code{read.csv} if \code{qdata}
+is a file name and therefore will get read from csv.}
 }
 \description{
 This function allows you to add a free-standing table to your project data.

--- a/tests/testthat/test_gcam_import.R
+++ b/tests/testthat/test_gcam_import.R
@@ -371,6 +371,28 @@ test_that('addQueryTable works.', {
               unlink(altfile)
           })
 
+test_that('addQueryTable read from csv works.', {
+    altfile <- tempfile()     # avoid disturbing our test case
+    query_name <- "CO2 concentrations"
+    query_name_test <- paste0(query_name, "_TEST")
+    prj <- loadProject(file.valid)
+    comp.data <- getQuery(prj, query_name)
+
+    write.table(comp.data, altfile, row.names=FALSE, sep="|") # switch things up to ensure
+                                                              # additional arguments get used
+                                                              # in addQueryTable
+    expect_silent(prj <- addQueryTable(prj, altfile, query_name_test,
+                                        saveProj=FALSE, # do not save test project
+                                        sep="|", stringsAsFactors = FALSE)) # use the additional arguments to pass
+                                                                            # through to read.csv
+    # We expect the data to be the same after being read back in but we do
+    # need to be careful to get the types to be the same to avoid that error
+    expect_equal(tibble::as_tibble(getQuery(prj, query_name_test)), comp.data)
+
+    ## remove the tempfile
+    unlink(altfile)
+})
+
 test_that('addSingleQuery works.', {
     query_name <- "CO2 concentrations"
     prj <- loadProject(file.valid)


### PR DESCRIPTION
Not sure what it was doing there in the first place besides causing trouble.  The tests work without it (as well as it's use in gcam_diagnostics).