### PR TITLE
Raise java memory limit to 4 GB when running model interface.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgcam
 Title: Tools for importing and working with GCAM results
-Version: 0.4.5
+Version: 0.4.6
 Authors@R: person("Robert", "Link", email = "robert.link@pnnl.gov", role = c("aut", "cre"))
 Description: This package provides tools for extracting data from GCAM
     output databases and importing that data into R for analysis.  The

--- a/R/querymi.R
+++ b/R/querymi.R
@@ -89,7 +89,7 @@ runQuery.localDBConn <- function(dbConn, query, scenarios=NULL, regions=NULL,
     cmd <- c(
         "java",
         paste("-cp", shQuote(dbConn$miclasspath)),
-        "-Xmx2g", #TODO: memory limits?
+        "-Xmx4g", #TODO: memory limits?
         paste0("-Dorg.basex.DBPATH=", shQuote(dbConn$dbPath)),
         paste0("-DModelInterface.SUPPRESS_OUTPUT=", dbConn$migabble),
         "org.basex.BaseX",
@@ -119,7 +119,7 @@ listScenariosInDB.localDBConn <- function(dbConn) {
     cmd <- c(
         "java",
         paste("-cp", shQuote(dbConn$miclasspath)),
-        "-Xmx2g", #TODO: memory limits?
+        "-Xmx4g", #TODO: memory limits?
         paste0("-Dorg.basex.DBPATH=", shQuote(dbConn$dbPath)),
         "org.basex.BaseX",
         "-smethod=csv",


### PR DESCRIPTION
This change is incompatible with 32-bit Java.  We don't actually
support 32-bit Java, but some users may have been getting by with it.
This change will break for them.  The solution is to upgrade to 64-bit
Java.

Fixes #31