### PR TITLE
Increase runQuery memory limit to 16 GB

### DIFF
--- a/R/querymi.R
+++ b/R/querymi.R
@@ -104,7 +104,7 @@ runQuery.localDBConn <- function(dbConn, query, scenarios=NULL, regions=NULL,
     cmd <- c(
         "java",
         paste("-cp", shQuote(dbConn$miclasspath)),
-        "-Xmx4g", #TODO: memory limits?
+        "-Xmx16g", #TODO: memory limits?
         paste0("-Dorg.basex.DBPATH=", shQuote(dbConn$dbPath)),
         paste0("-DModelInterface.SUPPRESS_OUTPUT=", dbConn$migabble),
         "org.basex.BaseX",


### PR DESCRIPTION
@rplzzz I tried my ghg emissions query "fix" (changing out the GHG emissions query for a version without the long function) and it was less effective than increasing the memory for speed and avoiding the memory limit.