### PR TITLE
Configurable Java max memory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgcam
 Title: Tools for importing and working with GCAM results
-Version: 1.0.0
+Version: 1.1.0
 Authors@R: c(person("Robert", "Link", email = "robert.link@pnnl.gov", role = c("aut", "cre", "lyr", "ard")),
              person("Pralit", "Patel", email="pralit.patel@pnnl.gov", role="aut"))
 Description: This package provides tools for extracting data from GCAM

--- a/R/querymi.R
+++ b/R/querymi.R
@@ -63,15 +63,20 @@ listScenariosInDB <- function(dbConn)
 #' \code{FALSE}, display console output.
 #' @param validatedb If \code{TRUE}, check that a simple db query works on the
 #' connection; otherwise, don't run the check.
+#' @param maxMemory Sets the maximum memory for Java which will be used to run
+#' the queries.  The default value is \code{"4g"}.  Users may need to reduce this
+#' value if they are using a 32-bit Java or increase it if they suspect they are
+#' running out of memory (by using \code{migabble} to check the log).  Note the
+#' numeric value can be suffixed with "g" for Gigabyte or "m" for Megabyte.
 #' @return A connection to a local BaseX databasse which can be used to run
 #' queries.
 #' @export
-localDBConn <- function(dbPath, dbFile, miclasspath=NULL, migabble=TRUE, validatedb=TRUE) {
+localDBConn <- function(dbPath, dbFile, miclasspath=NULL, migabble=TRUE, validatedb=TRUE, maxMemory="4g") {
     if(is.null(miclasspath)) {
         miclasspath = DEFAULT.MICLASSPATH()
     }
     db_inst <- structure(
-        list(miclasspath=miclasspath, dbPath=normalizePath(dbPath), dbFile=dbFile, migabble=migabble),
+        list(miclasspath=miclasspath, dbPath=normalizePath(dbPath), dbFile=dbFile, migabble=migabble, maxMemory=maxMemory),
         class="localDBConn")
 
     if(validatedb) {
@@ -106,7 +111,7 @@ runQuery.localDBConn <- function(dbConn, query, scenarios=NULL, regions=NULL,
     cmd <- c(
         "java",
         paste("-cp", shQuote(dbConn$miclasspath)),
-        "-Xmx16g", #TODO: memory limits?
+        paste0("-Xmx", dbConn$maxMemory),
         paste0("-Dorg.basex.DBPATH=", shQuote(dbConn$dbPath)),
         paste0("-DModelInterface.SUPPRESS_OUTPUT=", dbConn$migabble),
         "org.basex.BaseX",
@@ -141,7 +146,7 @@ listScenariosInDB.localDBConn <- function(dbConn) {
     cmd <- c(
         "java",
         paste("-cp", shQuote(dbConn$miclasspath)),
-        "-Xmx4g", #TODO: memory limits?
+        paste0("-Xmx", dbConn$maxMemory),
         paste0("-Dorg.basex.DBPATH=", shQuote(dbConn$dbPath)),
         "org.basex.BaseX",
         "-smethod=csv",

--- a/man/localDBConn.Rd
+++ b/man/localDBConn.Rd
@@ -5,7 +5,7 @@
 \title{Create a connection that can be used to run queries on a local GCAM database}
 \usage{
 localDBConn(dbPath, dbFile, miclasspath = NULL, migabble = TRUE,
-  validatedb = TRUE)
+  validatedb = TRUE, maxMemory = "4g")
 }
 \arguments{
 \item{dbPath}{The path in which the BaseX DBs are located.}
@@ -19,6 +19,12 @@ localDBConn(dbPath, dbFile, miclasspath = NULL, migabble = TRUE,
 
 \item{validatedb}{If \code{TRUE}, check that a simple db query works on the
 connection; otherwise, don't run the check.}
+
+\item{maxMemory}{Sets the maximum memory for Java which will be used to run
+the queries.  The default value is \code{"4g"}.  Users may need to reduce this
+value if they are using a 32-bit Java or increase it if they suspect they are
+running out of memory (by using \code{migabble} to check the log).  Note the
+numeric value can be suffixed with "g" for Gigabyte or "m" for Megabyte.}
 }
 \value{
 A connection to a local BaseX databasse which can be used to run


### PR DESCRIPTION
Make the maximum Java heap size for localDBConn an explicit argument as depending on users Java installation / use case the appropriate value may vary.

This closes #64